### PR TITLE
add `config_local_dir` (issue #68)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@ pub struct ProjectDirs {
     // base directories
     cache_dir:      PathBuf,
     config_dir:     PathBuf,
+    config_local_dir: PathBuf,
     data_dir:       PathBuf,
     data_local_dir: PathBuf,
     preference_dir: PathBuf,
@@ -440,6 +441,16 @@ impl ProjectDirs {
     /// | Windows | `{FOLDERID_RoamingAppData}`\\`_project_path_`\\config                   | C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config         |
     pub fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
+    }
+    /// Returns the path to the project's local config directory.
+    ///
+    /// |Platform | Value                                                                   | Example                                                        |
+    /// | ------- | ----------------------------------------------------------------------- | -------------------------------------------------------------- |
+    /// | Linux   | `$XDG_CONFIG_HOME`/`_project_path_` or `$HOME`/.config/`_project_path_` | /home/alice/.config/barapp                                     |
+    /// | macOS   | `$HOME`/Library/Application Support/`_project_path_`                    | /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App  |
+    /// | Windows | `{FOLDERID_LocalAppData}`\\`_project_path_`\\config                     | C:\Users\Alice\AppData\Local\Foo Corp\Bar App\config           |
+    pub fn config_local_dir(&self) -> &Path {
+        self.config_local_dir.as_path()
     }
     /// Returns the path to the project's data directory.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,17 +127,17 @@ pub struct UserDirs {
 /// ```
 #[derive(Debug, Clone)]
 pub struct ProjectDirs {
-    project_path:   PathBuf,
+    project_path:     PathBuf,
 
     // base directories
-    cache_dir:      PathBuf,
-    config_dir:     PathBuf,
+    cache_dir:        PathBuf,
+    config_dir:       PathBuf,
     config_local_dir: PathBuf,
-    data_dir:       PathBuf,
-    data_local_dir: PathBuf,
-    preference_dir: PathBuf,
-    runtime_dir:    Option<PathBuf>,
-    state_dir:      Option<PathBuf>
+    data_dir:         PathBuf,
+    data_local_dir:   PathBuf,
+    preference_dir:   PathBuf,
+    runtime_dir:      Option<PathBuf>,
+    state_dir:        Option<PathBuf>
 }
 
 impl BaseDirs {

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -63,6 +63,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
     if let Some(home_dir)  = dirs_sys::home_dir() {
         let cache_dir      = env::var_os("XDG_CACHE_HOME") .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".cache")).join(&project_path);
         let config_dir     = env::var_os("XDG_CONFIG_HOME").and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".config")).join(&project_path);
+        let config_local_dir = config_dir.clone();
         let data_dir       = env::var_os("XDG_DATA_HOME")  .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".local/share")).join(&project_path);
         let data_local_dir = data_dir.clone();
         let preference_dir = config_dir.clone();
@@ -73,6 +74,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
             project_path:   project_path,
             cache_dir:      cache_dir,
             config_dir:     config_dir,
+            config_local_dir,
             data_dir:       data_dir,
             data_local_dir: data_local_dir,
             preference_dir: preference_dir,

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -60,26 +60,26 @@ pub fn user_dirs() -> Option<UserDirs> {
 }
 
 pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
-    if let Some(home_dir)  = dirs_sys::home_dir() {
-        let cache_dir      = env::var_os("XDG_CACHE_HOME") .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".cache")).join(&project_path);
-        let config_dir     = env::var_os("XDG_CONFIG_HOME").and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".config")).join(&project_path);
+    if let Some(home_dir)    = dirs_sys::home_dir() {
+        let cache_dir        = env::var_os("XDG_CACHE_HOME") .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".cache")).join(&project_path);
+        let config_dir       = env::var_os("XDG_CONFIG_HOME").and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".config")).join(&project_path);
         let config_local_dir = config_dir.clone();
-        let data_dir       = env::var_os("XDG_DATA_HOME")  .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".local/share")).join(&project_path);
-        let data_local_dir = data_dir.clone();
-        let preference_dir = config_dir.clone();
-        let runtime_dir    = env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys::is_absolute_path).map(|o| o.join(&project_path));
-        let state_dir      = env::var_os("XDG_STATE_HOME") .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".local/state")).join(&project_path);
+        let data_dir         = env::var_os("XDG_DATA_HOME")  .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".local/share")).join(&project_path);
+        let data_local_dir   = data_dir.clone();
+        let preference_dir   = config_dir.clone();
+        let runtime_dir      = env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys::is_absolute_path).map(|o| o.join(&project_path));
+        let state_dir        = env::var_os("XDG_STATE_HOME") .and_then(dirs_sys::is_absolute_path).unwrap_or_else(|| home_dir.join(".local/state")).join(&project_path);
 
         let project_dirs = ProjectDirs {
-            project_path:   project_path,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            config_local_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            preference_dir: preference_dir,
-            runtime_dir:    runtime_dir,
-            state_dir:      Some(state_dir)
+            project_path:     project_path,
+            cache_dir:        cache_dir,
+            config_dir:       config_dir,
+            config_local_dir: config_local_dir,
+            data_dir:         data_dir,
+            data_local_dir:   data_local_dir,
+            preference_dir:   preference_dir,
+            runtime_dir:      runtime_dir,
+            state_dir:        Some(state_dir)
         };
         Some(project_dirs)
     } else {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -61,24 +61,24 @@ pub fn user_dirs() -> Option<UserDirs> {
 }
 
 pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
-    if let Some(home_dir)  = dirs_sys::home_dir() {
-        let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
-        let config_dir     = home_dir.join("Library/Application Support").join(&project_path);
+    if let Some(home_dir)    = dirs_sys::home_dir() {
+        let cache_dir        = home_dir.join("Library/Caches").join(&project_path);
+        let config_dir       = home_dir.join("Library/Application Support").join(&project_path);
         let config_local_dir = config_dir.clone();
-        let data_dir       = home_dir.join("Library/Application Support").join(&project_path);
-        let data_local_dir = data_dir.clone();
-        let preference_dir = home_dir.join("Library/Preferences").join(&project_path);
+        let data_dir         = home_dir.join("Library/Application Support").join(&project_path);
+        let data_local_dir   = data_dir.clone();
+        let preference_dir   = home_dir.join("Library/Preferences").join(&project_path);
 
         let project_dirs = ProjectDirs {
-            project_path:   project_path,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            config_local_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            preference_dir: preference_dir,
-            runtime_dir:    None,
-            state_dir:      None
+            project_path:     project_path,
+            cache_dir:        cache_dir,
+            config_dir:       config_dir,
+            config_local_dir: config_local_dir,
+            data_dir:         data_dir,
+            data_local_dir:   data_local_dir,
+            preference_dir:   preference_dir,
+            runtime_dir:      None,
+            state_dir:        None
         };
         Some(project_dirs)
     } else {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -64,6 +64,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
     if let Some(home_dir)  = dirs_sys::home_dir() {
         let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
         let config_dir     = home_dir.join("Library/Application Support").join(&project_path);
+        let config_local_dir = config_dir.clone();
         let data_dir       = home_dir.join("Library/Application Support").join(&project_path);
         let data_local_dir = data_dir.clone();
         let preference_dir = home_dir.join("Library/Preferences").join(&project_path);
@@ -72,6 +73,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
             project_path:   project_path,
             cache_dir:      cache_dir,
             config_dir:     config_dir,
+            config_local_dir,
             data_dir:       data_dir,
             data_local_dir: data_local_dir,
             preference_dir: preference_dir,

--- a/src/win.rs
+++ b/src/win.rs
@@ -76,15 +76,15 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
         let preference_dir   = config_dir.clone();
 
         let project_dirs = ProjectDirs {
-            project_path:   project_path,
-            cache_dir:      cache_dir,
-            config_dir:     config_dir,
-            config_local_dir,
-            data_dir:       data_dir,
-            data_local_dir: data_local_dir,
-            preference_dir: preference_dir,
-            runtime_dir:    None,
-            state_dir:      None
+            project_path:     project_path,
+            cache_dir:        cache_dir,
+            config_dir:       config_dir,
+            config_local_dir: config_local_dir,
+            data_dir:         data_dir,
+            data_local_dir:   data_local_dir,
+            preference_dir:   preference_dir,
+            runtime_dir:      None,
+            state_dir:        None
         };
         Some(project_dirs)
     } else {

--- a/src/win.rs
+++ b/src/win.rs
@@ -71,6 +71,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
         let cache_dir        = app_data_local.join("cache");
         let data_local_dir   = app_data_local.join("data");
         let config_dir       = app_data_roaming.join("config");
+        let config_local_dir = app_data_local.join("config");
         let data_dir         = app_data_roaming.join("data");
         let preference_dir   = config_dir.clone();
 
@@ -78,6 +79,7 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
             project_path:   project_path,
             cache_dir:      cache_dir,
             config_dir:     config_dir,
+            config_local_dir,
             data_dir:       data_dir,
             data_local_dir: data_local_dir,
             preference_dir: preference_dir,


### PR DESCRIPTION
Adds a local config dir which is identical to `config_dir` on Linux and Mac. On Windows it uses AppData/Local instead of AppData/Roaming.

I only ran the tests on Linux cause I don't know how CI works and I don't have a Mac / Win system handy.