### PR TITLE
Update the repo link in metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors     = ["Simon Ochsenreither <simon@ochsenreither.de>"]
 description = "A tiny mid-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS."
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/soc/directories-rs"
+repository  = "https://github.com/dirs-dev/directories-rs"
 maintenance = { status = "actively-developed" }
 keywords    = ["xdg", "basedir", "app_dirs", "path", "folder"]
 


### PR DESCRIPTION
The original link works (301 Moved Permanently), but it really confused me for a while…